### PR TITLE
added migration check before setting default values.

### DIFF
--- a/lib/active_null/null_model_builder.rb
+++ b/lib/active_null/null_model_builder.rb
@@ -25,8 +25,10 @@ module ActiveNull
           end
         end
 
-        model.column_defaults.each do |field, default|
-          define_method(field.to_sym) { default }
+        unless ActiveRecord::Migrator.needs_migration?
+          model.column_defaults.each do |field, default|
+            define_method(field.to_sym) { default }
+          end
         end
 
         def nil?


### PR DESCRIPTION
This may be bad practice, but I have worked with multiple rails apps where people create seed data in the migration files (e.g. an `update_all` column to update a static value). This check just ensures that the default values on a `NullObject` don't get set if there are current migrations, in other words `#null_model` does not set column defaults during `db:migrate`.
