### PR TITLE
Allowing the user to define an alias for the null method

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ You can then safely do something like:
 @post = Post.find_by(id: 1).decorate
 ```
 
+You can also define an alias for your `null` method for convenience
+
+```ruby
+class User < ActiveRecord::Base
+  extend ActiveNull
+
+  null_model(:guest)
+end
+
+User.first    # => <User>
+User.null     # => <null:User>
+User.guest    # => <null:User>
+```
+
+
 ## Contributing
 
 1. Fork it ( https://github.com/Originate/active_null/fork )

--- a/lib/active_null.rb
+++ b/lib/active_null.rb
@@ -14,9 +14,14 @@ module ActiveNull
     @polymorphic_null_defaults || {}
   end
 
-  def null_model(&block)
+  def null_model(method_name=nil, &block)
     @null_model_overrides = if block_given?
       Module.new.tap { |m| m.module_eval(&block) }
+
+    if method_name
+      singleton_class.class_eval do
+        define_method(method_name) { null }
+      end
     end
   end
 

--- a/spec/active_null_spec.rb
+++ b/spec/active_null_spec.rb
@@ -21,6 +21,11 @@ describe ActiveNull do
     specify { expect(Test::TestModel.null).to be_instance_of(Test::NullTestModel) }
   end
 
+  describe '.guest' do
+    specify { expect(User.null).to be_instance_of(NullUser) }
+    specify { expect(User.guest).to be_instance_of(NullUser) }
+  end
+
   describe '.null_model' do
     specify { expect(Post.null.override).to eq 'I am an override.' }
   end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -15,6 +15,8 @@ end
 class User < ActiveRecord::Base
   extend ActiveNull
   has_many :comments, as: :author
+
+  null_model(:guest)
 end
 
 class Comment < ActiveRecord::Base


### PR DESCRIPTION
Hello Alex,

I installed this gem today and it looks great. I love Naught and I think this is a great addition. Thank you for that!

The only thing I wished it had was the ability to change (or alias) the `null` method name. I implemented that and provided an example for the readme.

I think this addition can help make the client code more readable.

For example, I like to call guest users "guest" and having that name available makes the code better in my opinion.

Thanks again.

Federico