### PR TITLE
Rails 6.1 compatibility / Fix deprecation warnings in Rails 6.0

### DIFF
--- a/active_null.gemspec
+++ b/active_null.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'activerecord', '~> 4.2'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'draper', '~> 2.1'
   spec.add_development_dependency 'coveralls'
 end

--- a/lib/active_null/null_model_builder.rb
+++ b/lib/active_null/null_model_builder.rb
@@ -92,12 +92,22 @@ module ActiveNull
     end
 
     def full_name
-      return name if model.parent == Object
-      "#{model.parent.name}::#{name}"
+      return name if module_parent == Object
+      "#{module_parent_name}::#{name}"
     end
 
     def set_null_model(null)
-      model.parent.const_set name, null
+      module_parent.const_set name, null
+    end
+
+    private
+
+    def module_parent
+      @module_parent ||= model.try(:module_parent) || model.parent
+    end
+
+    def module_parent_name
+      @module_parent_name ||= model.try(:module_parent_name) || model.parent.name
     end
   end
 end


### PR DESCRIPTION
Using this gem on Rails 6.0 results in a deprecation warning: `DEPRECATION WARNING: `Module#parent` has been renamed to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1.` This change is documented [here](https://github.com/rails/rails/pull/34051).

This PR resolves this issue for Rails 6+ while maintaining backward compatibility with previous versions.